### PR TITLE
moved cookie route to cmdi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,14 +37,14 @@
       }
     },
     "@contrast/test-bench-content": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@contrast/test-bench-content/-/test-bench-content-2.1.0.tgz",
-      "integrity": "sha512-ZAsPcZezchILc9Yi4niTT4iNHFLLzl0AvWnDoQ+x1LsCvDdjC9upCJabDWKDYKMx8X4dRE/bpv6T/oiKS+Mzvw=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@contrast/test-bench-content/-/test-bench-content-2.2.0.tgz",
+      "integrity": "sha512-wYNcKuLlpbJhxD4NUR50EedhO/WptwkfEkTxhzrBLcQK6Gv1MyV3ZaBbw/mgwC9h3+/ThxiTtri9Xd8lNs+k2A=="
     },
     "@contrast/test-bench-utils": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-2.2.2.tgz",
-      "integrity": "sha512-Ae4Vie9WMER5nSTfLG8hAhAMQhZcGA86FxsIdgEFkqL00wTKyhEEP2761T+t/fExorcPcBcf9n1lSi3+dejL3g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-2.3.0.tgz",
+      "integrity": "sha512-YITlzjuG2oJEuOAJIJUF5+1QoYXxrL3fjkkvSnSADBbMkZf/GDIycMndxVZ+yGmnhH9UVK2SuuqsAcnqZobwCQ==",
       "requires": {
         "axios": "^0.19.0",
         "bent": "^1.5.13",
@@ -5273,9 +5273,9 @@
       }
     },
     "sequelize": {
-      "version": "5.21.1",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.21.1.tgz",
-      "integrity": "sha512-JI+53MwcClfCFUPJT/l2dDzSpEzWAueyCZus33L/yhJxKTisfdd9OHrUPQ6/dI5nR5eIYT/EafrjkqTAlEQS2w==",
+      "version": "5.21.2",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.21.2.tgz",
+      "integrity": "sha512-MEqJ9NwQi4oy/ylLb2WkfPmhki/BOXC/gJfc8uWUUTETcpLwD1y/5bI1kqVh+qWcECHNsE9G4lmhj5hFbsxqvA==",
       "requires": {
         "bluebird": "^3.5.0",
         "cls-bluebird": "^2.1.0",
@@ -5738,9 +5738,9 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "qs": {
-          "version": "6.9.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.0.tgz",
-          "integrity": "sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA=="
+          "version": "6.9.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
+          "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
         },
         "readable-stream": {
           "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "node": ">=8.3.0"
   },
   "dependencies": {
-    "@contrast/test-bench-content": "^2.1.0",
-    "@contrast/test-bench-utils": "^2.2.2",
+    "@contrast/test-bench-content": "^2.2.0",
+    "@contrast/test-bench-utils": "^2.3.0",
     "@hapi/glue": "^5.0.0",
     "@hapi/hapi": "^17.8.5",
     "@hapi/hoek": "^6.1.3",


### PR DESCRIPTION
When we were abstracting out sinks and views the cookie source routes were applied to reflected xss. This is only applicable to assess. I moved them to cmd injection. To verify this works:

 * Run agent with this PR
 * curl http://localhost:3000/cmdInjection/cookies/childProcessExec/unsafe -X POST -b "input=test&whoami"

It should report cmd injection in protect. It should report finding in assess